### PR TITLE
Bump misc docker-compose-linux/mac prometheus to 2.11.2

### DIFF
--- a/misc/docker-compose-linux.yml
+++ b/misc/docker-compose-linux.yml
@@ -3,7 +3,7 @@ version: '3'
 services:
   prometheus:
     container_name: prometheus
-    image: ${PROM_IMAGE:-prom/prometheus:v2.5.0}
+    image: ${PROM_IMAGE:-prom/prometheus:v2.11.2}
     ports:
       - 127.0.0.1:9090:9090
     network_mode: host

--- a/misc/prometheus/linux.yml
+++ b/misc/prometheus/linux.yml
@@ -44,6 +44,5 @@ remote_write:
       max_shards: 50
       max_samples_per_send: 100000
       batch_send_deadline: 5s
-      max_retries: 10
       min_backoff: 30ms
       max_backoff: 100ms

--- a/misc/prometheus/mac.yml
+++ b/misc/prometheus/mac.yml
@@ -44,6 +44,5 @@ remote_write:
       max_shards: 50
       max_samples_per_send: 100000
       batch_send_deadline: 5s
-      max_retries: 10
       min_backoff: 30ms
       max_backoff: 100ms


### PR DESCRIPTION
Bumping prometheus to 2.11.2

Removed max_retries from `remote_write` because of https://github.com/prometheus/prometheus/pull/5649

>  remote write no longer uses the max retries config option. We retry endlessly for recoverable errors.