### PR TITLE
Add .gotrelease.yml

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,39 @@
+# This is an example goreleaser.yaml file with some sane defaults.
+# Make sure to check the documentation at http://goreleaser.com
+before:
+  hooks:
+    # you may remove this if you don't use vgo
+    - go mod download
+    # you may remove this if you don't need go generate
+    - go generate ./...
+builds:
+  -
+    binary: "promhouse"
+    main: ./cmd/promhouse/main.go
+    env:
+      - CGO_ENABLED=0
+    ignore:
+      - goos: darwin
+        goarch: 386
+      - goos: linux
+        goarch: arm
+        goarm: 7
+      - goos: windows
+
+archives:
+- replacements:
+    darwin: Darwin
+    linux: Linux
+    windows: Windows
+    386: i386
+    amd64: x86_64
+checksum:
+  name_template: 'checksums.txt'
+snapshot:
+  name_template: "{{ .Tag }}-next"
+changelog:
+  sort: asc
+  filters:
+    exclude:
+    - '^docs:'
+    - '^test:'


### PR DESCRIPTION
goreleaser attaches compiled versions of binary to releases section

basically to release its enough to issue following commands

```
$ export GITHUB_TOKEN=`YOUR_GH_TOKEN`
$ git tag -a v0.1.0 -m "First release"
$ git push origin v0.1.0
$ goreleaser
```

Hopefully you can attach this to CI as I don't have rights to do so.