### PR TITLE
Change ClickHouse Docker repository.

### DIFF
--- a/misc/docker-compose-mac.yml
+++ b/misc/docker-compose-mac.yml
@@ -22,7 +22,7 @@ services:
 
   clickhouse:
     container_name: clickhouse
-    image: yandex/clickhouse-server
+    image: clickhouse/clickhouse-server
     ports:
       - 127.0.0.1:8123:8123
       - 127.0.0.1:9000:9000


### PR DESCRIPTION
New versions are located in clickhouse/clickhouse-server only.